### PR TITLE
Removes validation deprecated call

### DIFF
--- a/Sources/ContentApi/Content/CreateContentController.swift
+++ b/Sources/ContentApi/Content/CreateContentController.swift
@@ -20,7 +20,7 @@ public extension CreateContentController {
     }
     
     func create(_ req: Request) throws -> EventLoopFuture<Model.GetContent> {
-        try Model.CreateContent.validate(req)
+        try Model.CreateContent.validate(content: req)
         let input = try req.content.decode(Model.CreateContent.self)
         let model = Model()
         return self.beforeCreate(req: req, model: model, content: input)

--- a/Sources/ContentApi/Content/PatchContentController.swift
+++ b/Sources/ContentApi/Content/PatchContentController.swift
@@ -20,7 +20,7 @@ public extension PatchContentController {
     }
     
     func patch(_ req: Request) throws -> EventLoopFuture<Model.GetContent> {
-        try Model.PatchContent.validate(req)
+        try Model.PatchContent.validate(content: req)
         let patch = try req.content.decode(Model.PatchContent.self)
         return try self.find(req)
         .flatMap { model in

--- a/Sources/ContentApi/Content/UpdateContentController.swift
+++ b/Sources/ContentApi/Content/UpdateContentController.swift
@@ -20,7 +20,7 @@ public extension UpdateContentController {
     }
     
     func update(_ req: Request) throws -> EventLoopFuture<Model.GetContent> {
-        try Model.UpdateContent.validate(req)
+        try Model.UpdateContent.validate(content: req)
         let input = try req.content.decode(Model.UpdateContent.self)
         return try self.find(req)
         .flatMap { model in


### PR DESCRIPTION
- note: uses 'validate(content:)' instead 'validate()'